### PR TITLE
Revert "[DP-3147] Add `aria-expanded` attributes to Accordion button"

### DIFF
--- a/js/app/accordion.js
+++ b/js/app/accordion.js
@@ -22,15 +22,12 @@ It also toggles a single item open and closed on repeated clicks.
 
 	function initAccordions(){
 	    closeAllInactiveAccordionPanels();
-        $(".accordion__title").off("click").on("click", function(e) {
-            e.preventDefault();
+        $(".accordion__title").off("click").on("click", function() {
             if ($(this).hasClass("active")) {
                 $(this).removeClass("active");
-                $(this).children("button").attr("aria-expanded","false");
                 $(this).next(".accordion__description").removeClass("active").slideUp();
             } else {
                 $(this).addClass("active");
-                $(this).children("button").attr("aria-expanded","true");
                 $(this).next(".accordion__description").addClass("active").slideDown();
         	    closeAllInactiveAccordionPanels();
             }

--- a/js/appsrc/accordion.js
+++ b/js/appsrc/accordion.js
@@ -22,15 +22,12 @@ It also toggles a single item open and closed on repeated clicks.
 
 	function initAccordions(){
 	    closeAllInactiveAccordionPanels();
-        $(".accordion__title").off("click").on("click", function(e) {
-            e.preventDefault();
+        $(".accordion__title").off("click").on("click", function() {
             if ($(this).hasClass("active")) {
                 $(this).removeClass("active");
-                $(this).children("button").attr("aria-expanded","false");
                 $(this).next(".accordion__description").removeClass("active").slideUp();
             } else {
                 $(this).addClass("active");
-                $(this).children("button").attr("aria-expanded","true");
                 $(this).next(".accordion__description").addClass("active").slideDown();
         	    closeAllInactiveAccordionPanels();
             }


### PR DESCRIPTION
Reverts UCL-WAMS/indigo3#92

As agreed into today's dev stand-up and in order to revert all the indigo3 enhancements related to DP-3164