### PR TITLE
[DP-3147] Add aria-expanded attributes to Accordion button

### DIFF
--- a/js/app/accordion.js
+++ b/js/app/accordion.js
@@ -22,12 +22,15 @@ It also toggles a single item open and closed on repeated clicks.
 
 	function initAccordions(){
 	    closeAllInactiveAccordionPanels();
-        $(".accordion__title").off("click").on("click", function() {
+        $(".accordion__title").off("click").on("click", function(e) {
+            e.preventDefault();
             if ($(this).hasClass("active")) {
                 $(this).removeClass("active");
+                $(this).children("button").attr("aria-expanded","false");
                 $(this).next(".accordion__description").removeClass("active").slideUp();
             } else {
                 $(this).addClass("active");
+                $(this).children("button").attr("aria-expanded","true");
                 $(this).next(".accordion__description").addClass("active").slideDown();
         	    closeAllInactiveAccordionPanels();
             }

--- a/js/appsrc/accordion.js
+++ b/js/appsrc/accordion.js
@@ -22,12 +22,15 @@ It also toggles a single item open and closed on repeated clicks.
 
 	function initAccordions(){
 	    closeAllInactiveAccordionPanels();
-        $(".accordion__title").off("click").on("click", function() {
+        $(".accordion__title").off("click").on("click", function(e) {
+            e.preventDefault();
             if ($(this).hasClass("active")) {
                 $(this).removeClass("active");
+                $(this).children("button").attr("aria-expanded","false");
                 $(this).next(".accordion__description").removeClass("active").slideUp();
             } else {
                 $(this).addClass("active");
+                $(this).children("button").attr("aria-expanded","true");
                 $(this).next(".accordion__description").addClass("active").slideDown();
         	    closeAllInactiveAccordionPanels();
             }


### PR DESCRIPTION
NEW PR SINCE #97 REVERTED

Story Link:
https://ucldata.atlassian.net/browse/DP-3147

What does this PR do?
- When accordion is expanded, add `aria-expanded=true` and `aria-expanded=false` when closed.
- `e.preventDefault()` added to stop page refresh on programme finder facet accordions.

Linked to:
[DP-3164] Programme finder keyboard navigability
[DP-3147] Fix issue with keyboard navigability of general accordions

[DP-3164]: https://ucldata.atlassian.net/browse/DP-3164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DP-3147]: https://ucldata.atlassian.net/browse/DP-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ